### PR TITLE
Spectra plugin test

### DIFF
--- a/includes/Blocks/BlockTemplates.php
+++ b/includes/Blocks/BlockTemplates.php
@@ -21,8 +21,11 @@ class BlockTemplates {
 	}
 
 	public function remove_template_blocks( $allowed_block_types, $block_editor_context ) {
+		//spectra plugin aka ultimate addons for gutenberg does not register blocks properly so they would be hidden
+		if ( vczapi_is_plugin_active( 'ultimate-addons-for-gutenberg/ultimate-addons-for-gutenberg.php' ) ) {
+			return $allowed_block_types;
+		}
 		$registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
-
 		if ( $block_editor_context->name == 'core/edit-post' ) {
 			unset( $registered_blocks['vczapi/single-zoom-meeting'] );
 
@@ -150,7 +153,7 @@ class BlockTemplates {
 			) {
 				$block['attrs']['theme'] = wp_get_theme()->get_stylesheet();
 			}
-			$modified_with_theme_template_content .= serialize_block($block);
+			$modified_with_theme_template_content .= serialize_block( $block );
 
 		}
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -4,6 +4,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if(!function_exists('vczapi_is_plugin_active')){
+	function vczapi_is_plugin_active( $plugin ) {
+		$active = false;
+		// check for plugin using plugin name
+		if ( in_array( $plugin, apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
+			$active = true;
+		}
+
+		return $active;
+	}
+}
+
+
 if ( ! function_exists( 'dump' ) ) {
 	/**
 	 * @author Deepen


### PR DESCRIPTION
Spectra plugin aka ultimate addons for gutenberg does not register blocks properly so they were hidden by our code for allowed_block_types all.
