### PR TITLE
Block Template Causing All Pages / Posts to revert to Single Zoom Meeting template

### DIFF
--- a/includes/Blocks/BlockTemplates.php
+++ b/includes/Blocks/BlockTemplates.php
@@ -37,12 +37,9 @@ class BlockTemplates {
 	}
 
 	public function add_meetings_block_template( $query_results, $query ) {
-
-//		var_dump($query_results);
-
 		$slugs = $query['slug__in'] ?? [];
 
-		if ( ! is_admin() && ! empty( $slugs ) && ! in_array( 'single-zoom-meetings', $slugs ) ) {
+		if ( ! empty( $slugs ) && ! in_array( 'single-zoom-meetings', $slugs ) && ! in_array( 'single-zoom-meeting', $slugs ) ) {
 			return $query_results;
 		}
 


### PR DESCRIPTION
Reproduce Issue:
- When Zoom is active - create new page with any content
- Save Page and Refresh
- You will notice the template has been changed to single-zoom-meeting

The patch fixes this issue while retaining the intended functionality